### PR TITLE
Validate name overrides whenever they are used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,19 +165,19 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
-			<scope>compile</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
 			<version>${hamcrest.version}</version>
-			<scope>compile</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>${mockito.version}</version>
-			<scope>compile</scope>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/daverog/jsonld/tree/RdfTreeGenerator.java
+++ b/src/main/java/daverog/jsonld/tree/RdfTreeGenerator.java
@@ -9,7 +9,7 @@ import java.util.*;
 public class RdfTreeGenerator {
 
     private final String rdfResultOntologyPrefix;
-
+		private final RdfTreeValidator rdfTreeValidator = new RdfTreeValidator();
 
     enum TreeType {
         UNKNOWN,
@@ -30,8 +30,7 @@ public class RdfTreeGenerator {
     }
 
     public RdfTree generateRdfTree(Model model, Map<String, String> nameOverrides) throws RdfTreeException {
-	RdfTreeValidator rdfTreeValidator = new RdfTreeValidator();
-        rdfTreeValidator.KeysCannotHaveSameValue(nameOverrides); 
+        rdfTreeValidator.keysCannotHaveSameValue(nameOverrides); 
         return generateRdfTree(model, Lists.<String>newArrayList(), nameOverrides);
     }
 
@@ -40,6 +39,8 @@ public class RdfTreeGenerator {
     }
 
     public RdfTree generateRdfTree(Model model, List<String> prioritisedNamespaces, Map<String, String> nameOverrides) throws RdfTreeException {
+        rdfTreeValidator.keysCannotHaveSameValue(nameOverrides);
+
         NameResolver nameResolver = new NameResolver(model, prioritisedNamespaces, nameOverrides, rdfResultOntologyPrefix);
 
         TreeType treeType = TreeType.UNKNOWN;

--- a/src/main/java/daverog/jsonld/tree/RdfTreeValidator.java
+++ b/src/main/java/daverog/jsonld/tree/RdfTreeValidator.java
@@ -3,13 +3,11 @@ package daverog.jsonld.tree;
 import com.google.common.base.Function;
 import com.google.common.collect.*;
 
-import org.junit.*;
-
 import java.util.*;
 
 public class RdfTreeValidator {
 
-    public void KeysCannotHaveSameValue(Map<String, String> map) throws IllegalArgumentException {
+    public void keysCannotHaveSameValue(Map<String, String> map) throws IllegalArgumentException {
         SetMultimap<String, String> multimap = Multimaps.forMap(map);
         Multimap<String, String> inverse = Multimaps.invertFrom(multimap, HashMultimap.<String, String> create()); 
 	for (Collection collection : inverse.asMap().values()) {

--- a/src/test/java/daverog/jsonld/tree/RdfTreeGeneratorTest.java
+++ b/src/test/java/daverog/jsonld/tree/RdfTreeGeneratorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 
 import org.junit.rules.ExpectedException;
 import org.junit.*;
@@ -821,7 +822,7 @@ public class RdfTreeGeneratorTest {
             "}", rdfTree.asJson());
     }
 
-    @Rule public ExpectedException exception = ExpectedException.none(); 
+    @Rule public ExpectedException exception = ExpectedException.none();
     @Test
     public void disallow_two_uris_from_having_the_same_alias() throws RdfTreeException { 
         Model model = ModelUtils.createJenaModel("<uri:a> <uri:b> <uri:c> .");
@@ -830,4 +831,14 @@ public class RdfTreeGeneratorTest {
         generator.generateRdfTree(model, ImmutableMap.of("http://purl.org/ns/a", "a", "http://purl.org/ns/b", "a", "http://purl.org/ns/c", "c")); 
     }
 
+    @Test
+    public void disallow_two_uris_from_having_the_same_alias_when_given_prioritised_namespaces() throws RdfTreeException { 
+        Model model = ModelUtils.createJenaModel("<uri:a> <uri:b> <uri:c> .");
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("An alias cannnot have multiple URI's. The values are: [http://purl.org/ns/b, http://purl.org/ns/a]");
+        generator.generateRdfTree(
+            model,
+            ImmutableList.of("http://purl.org/ns/a", "http://purl.org/ns/b"),
+            ImmutableMap.of("http://purl.org/ns/a", "a", "http://purl.org/ns/b", "a", "http://purl.org/ns/c", "c")); 
+    }
 }

--- a/src/test/java/daverog/jsonld/tree/RdfTreeValidatorTest.java
+++ b/src/test/java/daverog/jsonld/tree/RdfTreeValidatorTest.java
@@ -14,6 +14,6 @@ public class RdfTreeValidatorTest {
 	RdfTreeValidator rdfTreeValidator = new RdfTreeValidator();
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("An alias cannnot have multiple URI's. The values are: [http://purl.org/ns/b, http://purl.org/ns/a]");
-        rdfTreeValidator.KeysCannotHaveSameValue(ImmutableMap.of("http://purl.org/ns/a", "a", "http://purl.org/ns/b", "a", "http://purl.org/ns/c", "c")); 
+        rdfTreeValidator.keysCannotHaveSameValue(ImmutableMap.of("http://purl.org/ns/a", "a", "http://purl.org/ns/b", "a", "http://purl.org/ns/c", "c")); 
     }
 }


### PR DESCRIPTION
- Ensure that construction of tree generator validates any nameOverrides.
- Minor clean-up.
